### PR TITLE
build!: Cross build ARM on ubuntu-22.04

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -38,7 +38,7 @@ jobs:
   upload-binaries:
     needs: release-plz-release
     if: needs.release-plz-release.outputs.releases != '[]'
-    name: ${{ matrix.target.name }} / ${{ matrix.release.tag }} / ${{ matrix.release.package_name }}
+    name: ${{ matrix.target.name }} / ${{ matrix.release.tag }} / ${{ matrix.target.os }}
     strategy:
       fail-fast: false # Don't cancel all jobs if one fails
       matrix:
@@ -47,7 +47,7 @@ jobs:
           - name: x86_64-unknown-linux-musl
             os: ubuntu-24.04
           - name: aarch64-unknown-linux-musl
-            os: ubuntu-24.04-arm
+            os: ubuntu-24.04
           - name: x86_64-apple-darwin
             os: macos-13
           - name: aarch64-apple-darwin

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ install_binary() {
     if [ ! -w "${install_dir}" ]; then
         echo "You do not have write permissions to '${install_dir}'."
         echo "To perform a system-wide install, re-run with sudo:"
-        echo "  sudo curl -sSfL https://cloudray.io/install.sh | bash"
+        echo "  curl -sSfL https://cloudray.io/install.sh | sudo bash"
         echo
         echo "Or specify a custom installation directory via the INSTALL_DIR environment variable, for example:"
         echo "  curl -sSfL https://cloudray.io/install.sh | INSTALL_DIR=\"\$HOME/bin\" bash"


### PR DESCRIPTION
This is to resolve issue like following from https://github.com/cloudray-io/cloudray-agent/actions/runs/14824911565/job/41616807175

```
  Installing /home/runner/.cargo/bin/cross
  Installing /home/runner/.cargo/bin/cross-util
   Installed package `cross v0.2.5` (executables `cross`, `cross-util`)
+ cross build --release --bin cloudray-agent --target aarch64-unknown-linux-musl
error: toolchain 'stable-x86_64-unknown-linux-gnu' may not be able to run on this system
note: to build software for that platform, try `rustup target add x86_64-unknown-linux-gnu` instead
note: add the `--force-non-host` flag to install the toolchain anyway
Error: 
   0: couldn't install toolchain `stable-x86_64-unknown-linux-gnu`
   1: `rustup toolchain add stable-x86_64-unknown-linux-gnu --profile minimal` failed with exit status: 1
```