### PR TITLE
feat: [Experimental] Send nanoseconds timestamp for Runlog outputs.

### DIFF
--- a/pb/A2o.proto
+++ b/pb/A2o.proto
@@ -91,9 +91,10 @@ enum OutputStreamType {
 
 message RunlogOutputFragment {
   uint64 runlog_id = 1;
-  uint64 output_at_ts = 2;
+  uint64 output_at_ts = 2 [deprecated = true];
   OutputStreamType stream_type = 3;
   bytes output_fragment = 4;
+  uint64 output_at_nano_ts = 5;
 }
 
 message A2oMessage {

--- a/src/generated/pb/a2o.rs
+++ b/src/generated/pb/a2o.rs
@@ -92,12 +92,15 @@ pub struct RunlogFinished {
 pub struct RunlogOutputFragment {
     #[prost(uint64, tag = "1")]
     pub runlog_id: u64,
+    #[deprecated]
     #[prost(uint64, tag = "2")]
     pub output_at_ts: u64,
     #[prost(enumeration = "OutputStreamType", tag = "3")]
     pub stream_type: i32,
     #[prost(bytes = "vec", tag = "4")]
     pub output_fragment: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "5")]
+    pub output_at_nano_ts: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct A2oMessage {

--- a/src/o2a_messages/runlog_run.rs
+++ b/src/o2a_messages/runlog_run.rs
@@ -6,7 +6,7 @@ use crate::generated::pb::a2o::{
 };
 use crate::generated::pb::o2a::RunlogRun;
 use crate::message_queue::MessageQueue;
-use crate::utils::current_timestamp_secs;
+use crate::utils::{current_timestamp_nanos, current_timestamp_secs};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -115,6 +115,7 @@ where
         MessageQueue::push(A2oPayload::RunlogOutputFragment(RunlogOutputFragment {
             runlog_id,
             output_at_ts: current_timestamp_secs()?,
+            output_at_nano_ts: current_timestamp_nanos()?,
             stream_type: stream_type as i32,
             output_fragment: buffer[..n].to_vec(),
         }))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,3 +7,7 @@ pub fn current_timestamp() -> anyhow::Result<Duration> {
 pub fn current_timestamp_secs() -> anyhow::Result<u64> {
     current_timestamp().map(|d| d.as_secs())
 }
+
+pub fn current_timestamp_nanos() -> anyhow::Result<u64> {
+    current_timestamp().map(|d| d.as_nanos() as u64)
+}


### PR DESCRIPTION
Write now the output of runlog must be processed sequentially in the order it was generated.
However, if the agent sends timestamp in nanoseconds, Origin can parallelise saving output fragments to database and potentially make `agent/v1` requests process faster.